### PR TITLE
Update launch example in README for Bayer images

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,39 @@ Launch file based on [this example](https://github.com/ros2/demos/blob/foxy/comp
                         parameters = [{
                             'camera_settings_pfs': 'settings.pfs',
                             'camera_info_yaml': 'camera_calibration.yaml'
-                            }]
+                            }],
+                        remappings=[
+                            ('image', 'image_raw'),
+                        ]
                     ),
                     ComposableNode(
-                        name = 'pylon_camera_rectify',
-                        namespace = 'pylon_camera_node',
-                        package = 'image_proc',
-                        plugin = 'image_proc::RectifyNode'
+                        package='image_proc',
+                        plugin='image_proc::DebayerNode',
+                        name='debayer_node',
+                        namespace='pylon_camera_node',
+                    ),
+                    ComposableNode(
+                        package='image_proc',
+                        plugin='image_proc::RectifyNode',
+                        name='pylon_camera_rectify_mono',
+                        namespace='pylon_camera_node',
+                        # Remap subscribers and publishers
+                        remappings=[
+                            ('image', 'image_mono'),
+                            ('camera_info', 'camera_info'),
+                            ('image_rect', 'image_rect')
+                        ],
+                    ),
+                    ComposableNode(
+                        package='image_proc',
+                        plugin='image_proc::RectifyNode',
+                        name='pylon_camera_rectify_color',
+                        namespace='pylon_camera_node',
+                        # Remap subscribers and publishers
+                        remappings=[
+                            ('image', 'image_color'),
+                            ('image_rect', 'image_rect_color')
+                        ],
                     )
                 ]
         )


### PR DESCRIPTION
I found that the current launch file example in the README doesn't  work well for images that have a Bayer encoding, with the rectified image being in mono and having colored striations on top. Since the BayerRG8 is one of the default encoding available, it makes sense for the example launch file to be able to properly process it. This just updates the example to first call the Debayer node in image_proc in addition to the node to rectify it. 